### PR TITLE
📦 ci: fix test workflow to use setup-sbt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
+      - uses: sbt/setup-sbt@v1
       - name: Set unique package version
         id: set-version
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix test workflow to use `sbt/setup-sbt` action
+
 ## [v1.0.1]
 
 ### Changed


### PR DESCRIPTION
sbt is not included in setup-java anymore

See also:
- https://github.com/actions/setup-java/issues/712 or https://github.com/actions/setup-java/issues/694
- https://github.com/cucumber/cucumber-jvm-scala/issues/382
