### PR TITLE
🧪 test: update test project to publish to Central Host

### DIFF
--- a/test/.jvmopts
+++ b/test/.jvmopts
@@ -1,0 +1,1 @@
+-Dsun.net.client.defaultReadTimeout=60000

--- a/test/build.sbt
+++ b/test/build.sbt
@@ -1,5 +1,6 @@
 import ReleaseTransformations._
 import xerial.sbt.Sonatype.sonatypeSettings
+import xerial.sbt.Sonatype.sonatypeCentralHost
 
 // Metadata
 
@@ -48,6 +49,8 @@ lazy val root = (projectMatrix in file("."))
 
 Global / publishMavenStyle := true
 Global / publishTo := sonatypePublishToBundle.value
+// https://github.com/xerial/sbt-sonatype?tab=readme-ov-file#sonatype-central-host
+ThisBuild / sonatypeCredentialHost := sonatypeCentralHost
 
 // https://github.com/xerial/sbt-sonatype#using-with-sbt-release-plugin
 releaseCrossBuild := true


### PR DESCRIPTION
Relates to https://github.com/cucumber/cucumber-jvm-scala/issues/392

> Sonatype has [announced](https://central.sonatype.org/news/20250326_ossrh_sunset/) that they will sunset the OSSRH service that we're using to publish snapshots to oss.sonatype.org and releases to Maven Central. Therefore, we need to adjust our build to publish to their new [Central Publisher Portal](https://central.sonatype.org/publish/publish-portal-guide/) instead.